### PR TITLE
Håndterer både infotrygd saker og hotsak saker.

### DIFF
--- a/.github/workflows/deploy-hotsak-test.yml
+++ b/.github/workflows/deploy-hotsak-test.yml
@@ -1,0 +1,58 @@
+name: deploy-dev
+on:
+  push:
+    paths-ignore:
+      - "**.md"
+      - ".gitignore"
+      - "LICENCE"
+      - "CODEOWNERS"
+    branches:
+      - hotsak_meldiner
+env:
+  docker_image: docker.pkg.github.com/${{ github.repository }}/hm-oebs-listener:${{ github.sha }}
+jobs:
+  build:
+    name: Build, deploy to dev, and draft release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout latest code
+        uses: actions/checkout@v1
+      - name: Set up JDK 15
+        uses: actions/setup-java@v1
+        with:
+          java-version: 15
+      - name: Validate Gradle wrapper
+        uses: gradle/wrapper-validation-action@v1
+      - name: Setup gradle dependency cache
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+      - name: Build and Run tests
+        run: ./gradlew clean build
+      - name: pre-deploy
+        uses: navikt/digihot-deploy/actions/pre-deploy@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and publish Docker image
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          docker build --tag ${docker_image} .
+          docker login docker.pkg.github.com -u ${GITHUB_REPOSITORY} -p ${GITHUB_TOKEN}
+          docker push ${docker_image}
+      - name: deploy to dev-gcp
+        uses: nais/deploy/actions/deploy@v1
+        env:
+          APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}
+          CLUSTER: dev-gcp
+          RESOURCE: .nais/nais-dev.yml
+          VAR: image=${{ env.docker_image }}
+      - name: post-deploy
+        uses: navikt/digihot-deploy/actions/post-deploy@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/deploy-hotsak-test.yml
+++ b/.github/workflows/deploy-hotsak-test.yml
@@ -7,7 +7,7 @@ on:
       - "LICENCE"
       - "CODEOWNERS"
     branches:
-      - hotsak_meldiner
+      - hotsak_meldinger
 env:
   docker_image: docker.pkg.github.com/${{ github.repository }}/hm-oebs-listener:${{ github.sha }}
 jobs:

--- a/src/main/kotlin/no/nav/hjelpemidler/api/HotSak.kt
+++ b/src/main/kotlin/no/nav/hjelpemidler/api/HotSak.kt
@@ -1,0 +1,41 @@
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import mu.KotlinLogging
+import no.nav.hjelpemidler.configuration.Configuration
+import no.nav.hjelpemidler.metrics.SensuMetrics
+import no.nav.hjelpemidler.model.Message
+import no.nav.hjelpemidler.model.OrdrelinjeOebs
+import no.nav.hjelpemidler.model.toHotsakOrdrelinje
+import no.nav.hjelpemidler.slack.PostToSlack
+import java.time.LocalDateTime
+import java.util.UUID
+
+private val logg = KotlinLogging.logger {}
+private val sikkerlogg = KotlinLogging.logger("tjenestekall")
+private val mapperJson = jacksonObjectMapper().registerModule(JavaTimeModule())
+
+fun parseOebsOrdrelinje(ordrelinje: OrdrelinjeOebs) {
+
+    if (ordrelinje.hotSakSaksnummer == null || ordrelinje.hotSakSaksnummer.isBlank() ) {
+        logg.warn("Melding frå OEBS manglar HOTSAK saksnummer")
+        ordrelinje.fnrBruker = "MASKERT"
+        val message = mapperJson.writerWithDefaultPrettyPrinter().writeValueAsString(ordrelinje)
+        sikkerlogg.warn("Vedtak HOTSAK-melding med manglende informasjon: $message")
+        SensuMetrics().manglendeFeltForVedtakHOTSAK()
+
+        PostToSlack().post(
+            Configuration.application["SLACK_HOOK"]!!,
+            "*${Configuration.application["APP_PROFILE"]!!.toUpperCase()}* - Manglande felt i Vedtak Infotrygd-melding: ```$message```",
+            "#digihot-hotsak-varslinger-dev"
+        )
+        throw RuntimeException("Ugyldig Hotsak ordrelinje")
+    }
+}
+
+fun opprettHotsakOrdrelinje(ordrelinje: OrdrelinjeOebs) = Message(
+    eventId = UUID.randomUUID(),
+    eventName = "hm-NyOrdrelinje-hotsak",
+    opprettet = LocalDateTime.now(),
+    fnrBruker = ordrelinje.fnrBruker,
+    data = ordrelinje.toHotsakOrdrelinje()
+)

--- a/src/main/kotlin/no/nav/hjelpemidler/api/HotSak.kt
+++ b/src/main/kotlin/no/nav/hjelpemidler/api/HotSak.kt
@@ -25,7 +25,7 @@ fun parseOebsOrdrelinje(ordrelinje: OrdrelinjeOebs) {
 
         PostToSlack().post(
             Configuration.application["SLACK_HOOK"]!!,
-            "*${Configuration.application["APP_PROFILE"]!!.toUpperCase()}* - Manglande felt i Vedtak Infotrygd-melding: ```$message```",
+            "*${Configuration.application["APP_PROFILE"]!!.toUpperCase()}* - Manglende felt i Hotsak Oebs ordrelinje: ```$message```",
             "#digihot-hotsak-varslinger-dev"
         )
         throw RuntimeException("Ugyldig Hotsak ordrelinje")

--- a/src/main/kotlin/no/nav/hjelpemidler/api/InfotrygdSak.kt
+++ b/src/main/kotlin/no/nav/hjelpemidler/api/InfotrygdSak.kt
@@ -1,0 +1,41 @@
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import mu.KotlinLogging
+import no.nav.hjelpemidler.configuration.Configuration
+import no.nav.hjelpemidler.metrics.SensuMetrics
+import no.nav.hjelpemidler.model.Message
+import no.nav.hjelpemidler.model.OrdrelinjeOebs
+import no.nav.hjelpemidler.model.toOrdrelinje
+import no.nav.hjelpemidler.slack.PostToSlack
+import java.time.LocalDateTime
+import java.util.UUID
+
+private val logg = KotlinLogging.logger {}
+private val sikkerlogg = KotlinLogging.logger("tjenestekall")
+private val mapperJson = jacksonObjectMapper().registerModule(JavaTimeModule())
+
+fun parseInfotrygdOrdrelinje(ordrelinje: OrdrelinjeOebs) {
+
+    if (ordrelinje.saksblokkOgSaksnr.isBlank() || ordrelinje.vedtaksdato == null || ordrelinje.fnrBruker.isBlank()) {
+        logg.warn("Melding frå OEBS manglar saksblokk, vedtaksdato eller fnr!")
+        ordrelinje.fnrBruker = "MASKERT"
+        val message = mapperJson.writerWithDefaultPrettyPrinter().writeValueAsString(ordrelinje)
+        sikkerlogg.warn("Vedtak Infotrygd-melding med manglande informasjon: $message")
+        SensuMetrics().manglendeFeltForVedtakInfotrygd()
+
+        PostToSlack().post(
+            Configuration.application["SLACK_HOOK"]!!,
+            "*${Configuration.application["APP_PROFILE"]!!.toUpperCase()}* - Manglande felt i Vedtak Infotrygd-melding: ```$message```",
+            "#digihot-brukers-hjelpemiddelside-dev"
+        )
+       throw RuntimeException("Ugyldig Infotrygd ordelinje")
+    }
+}
+
+fun opprettInfotrygdOrdrelinje(ordrelinje: OrdrelinjeOebs) = Message(
+    eventId = UUID.randomUUID(),
+    eventName = "hm-NyOrdrelinje",
+    opprettet = LocalDateTime.now(),
+    fnrBruker = ordrelinje.fnrBruker,
+    data = ordrelinje.toOrdrelinje()
+)

--- a/src/main/kotlin/no/nav/hjelpemidler/api/InfotrygdSak.kt
+++ b/src/main/kotlin/no/nav/hjelpemidler/api/InfotrygdSak.kt
@@ -16,7 +16,7 @@ private val mapperJson = jacksonObjectMapper().registerModule(JavaTimeModule())
 
 fun parseInfotrygdOrdrelinje(ordrelinje: OrdrelinjeOebs) {
 
-    if (ordrelinje.saksblokkOgSaksnr.isBlank() || ordrelinje.vedtaksdato == null || ordrelinje.fnrBruker.isBlank()) {
+    if (ordrelinje.saksblokkOgSaksnr?.isBlank() == true || ordrelinje.vedtaksdato == null || ordrelinje.fnrBruker.isBlank()) {
         logg.warn("Melding frå OEBS manglar saksblokk, vedtaksdato eller fnr!")
         ordrelinje.fnrBruker = "MASKERT"
         val message = mapperJson.writerWithDefaultPrettyPrinter().writeValueAsString(ordrelinje)

--- a/src/main/kotlin/no/nav/hjelpemidler/api/OrdrelinjeAPI.kt
+++ b/src/main/kotlin/no/nav/hjelpemidler/api/OrdrelinjeAPI.kt
@@ -1,0 +1,165 @@
+package no.nav.hjelpemidler.api
+
+import com.fasterxml.jackson.dataformat.xml.XmlMapper
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.fasterxml.jackson.module.kotlin.readValue
+import io.ktor.application.ApplicationCall
+import io.ktor.application.call
+import io.ktor.http.HttpStatusCode
+import io.ktor.request.header
+import io.ktor.request.receiveText
+import io.ktor.response.respond
+import io.ktor.routing.Route
+import io.ktor.routing.post
+import mu.KotlinLogging
+import no.nav.helse.rapids_rivers.RapidsConnection
+import no.nav.hjelpemidler.configuration.Configuration
+import no.nav.hjelpemidler.metrics.SensuMetrics
+import no.nav.hjelpemidler.model.Message
+import no.nav.hjelpemidler.model.OrdrelinjeOebs
+import no.nav.hjelpemidler.model.erOpprettetFraHOTSAK
+import opprettHotsakOrdrelinje
+import opprettInfotrygdOrdrelinje
+import parseInfotrygdOrdrelinje
+import parseOebsOrdrelinje
+
+private val logg = KotlinLogging.logger {}
+private val sikkerlogg = KotlinLogging.logger("tjenestekall")
+private val mapperJson = jacksonObjectMapper().registerModule(JavaTimeModule())
+private val mapperXml = XmlMapper().registerModule(JavaTimeModule())
+
+internal fun Route.OrdrelinjeAPI(rapidApp: RapidsConnection?) {
+    post("/push") {
+        logg.info("incoming push")
+        val authHeader = call.request.header("Authorization").toString()
+        if (!authHeader.startsWith("Bearer ") || authHeader.substring(7) != Configuration.application["OEBSTOKEN"]!!) {
+            call.respond(HttpStatusCode.Unauthorized, "unauthorized")
+            return@post
+        }
+
+        try {
+            val ordrelinje = parseOrdrelinje(call) ?: return@post
+            validerOrdrelinje(ordrelinje)
+            val melding = if (ordrelinje.erOpprettetFraHOTSAK()) {
+                parseOebsOrdrelinje(ordrelinje)
+                opprettHotsakOrdrelinje(ordrelinje)
+            } else {
+                parseInfotrygdOrdrelinje(ordrelinje)
+                opprettInfotrygdOrdrelinje(ordrelinje)
+            }
+
+            publiserMelding(ordrelinje, rapidApp, melding)
+            call.respond(HttpStatusCode.OK)
+
+        } catch (e: RapidsAndRiverException) {
+            call.respond(HttpStatusCode.InternalServerError, "Feil under prosessering")
+            return@post
+        } catch (e: RuntimeException) {
+            call.respond(HttpStatusCode.OK)
+            return@post
+        }
+    }
+}
+
+private suspend fun parseOrdrelinje(call: ApplicationCall): OrdrelinjeOebs? {
+    var incomingFormatType = "JSON"
+    if (call.request.header("Content-Type").toString().contains("application/xml")) {
+        incomingFormatType = "XML"
+    }
+
+    val requestBody: String = call.receiveText()
+    SensuMetrics().meldingFraOebs()
+    if (Configuration.application["APP_PROFILE"] != "prod") {
+        sikkerlogg.info("Received $incomingFormatType push request from OEBS: $requestBody")
+    }
+
+    // Check for valid json request
+    val ordrelinje: OrdrelinjeOebs
+    try {
+        ordrelinje = if (incomingFormatType == "XML") {
+            mapperXml.readValue(requestBody)
+        } else {
+            mapperJson.readValue(requestBody)
+        }
+        if (Configuration.application["APP_PROFILE"] != "prod") {
+            sikkerlogg.info(
+                "Parsing incoming $incomingFormatType request successful: ${
+                    mapperJson.writeValueAsString(
+                        ordrelinje
+                    )
+                }"
+            )
+        }
+        SensuMetrics().oebsParsingOk()
+        return ordrelinje
+    } catch (e: Exception) {
+        // Deal with invalid json/xml in request
+        sikkerlogg.info("Parsing incoming $incomingFormatType request failed with exception (responding 4xx): $e")
+        if (Configuration.application["APP_PROFILE"] != "prod") {
+            sikkerlogg.info(
+                "$incomingFormatType in failed parsing: ${mapperJson.writeValueAsString(requestBody)}"
+            )
+        }
+        SensuMetrics().oebsParsingFeilet()
+        call.respond(HttpStatusCode.BadRequest, "bad request: $incomingFormatType not valid")
+        return null
+    }
+}
+
+
+private fun validerOrdrelinje(ordrelinje: OrdrelinjeOebs) {
+    if (ordrelinje.serviceforespørseltype != "Vedtak Infotrygd") {
+        if (ordrelinje.serviceforespørseltype == "") {
+            logg.info(
+                "Mottok melding fra oebs som ikke er en SF. Avbryter prosesseringen og returnerer"
+            )
+            SensuMetrics().sfTypeBlank()
+        } else {
+            logg.info(
+                "Mottok melding fra oebs med sf-type ${ordrelinje.serviceforespørseltype} og sf-status ${ordrelinje.serviceforespørselstatus}. " +
+                        "Avbryter prosesseringen og returnerer"
+            )
+            SensuMetrics().sfTypeUlikVedtakInfotrygd()
+        }
+        throw RuntimeException("Ugyldig ordrelinje")
+    } else {
+        SensuMetrics().sfTypeVedtakInfotrygd()
+    }
+
+    if (ordrelinje.hjelpemiddeltype != "Hjelpemiddel" &&
+        ordrelinje.hjelpemiddeltype != "Individstyrt hjelpemiddel"
+    ) {
+        logg.info("Mottok melding fra oebs med hjelpemiddeltype ${ordrelinje.hjelpemiddeltype}.")
+        SensuMetrics().irrelevantHjelpemiddeltype()
+        throw RuntimeException("Ugyldig ordrelinje")
+    } else {
+        SensuMetrics().rettHjelpemiddeltype()
+    }
+}
+
+private fun publiserMelding(
+    ordrelinje: OrdrelinjeOebs,
+    rapidApp: RapidsConnection?,
+    melding: Message
+) {
+    try {
+        logg.info("Publiserer ordrelinje med OebsId ${ordrelinje.oebsId} til rapid i miljø ${Configuration.application["APP_PROFILE"]}")
+        rapidApp!!.publish(ordrelinje.fnrBruker, mapperJson.writeValueAsString(melding))
+        SensuMetrics().meldingTilRapidSuksess()
+
+        // TODO: Remove logging when interface stabilizes
+        ordrelinje.fnrBruker = "MASKERT"
+        sikkerlogg.info(
+            "Ordrelinje med OebsId ${ordrelinje.oebsId} mottatt og sendt til rapid: ${
+                mapperJson.writeValueAsString(
+                    ordrelinje
+                )
+            }"
+        )
+    } catch (e: Exception) {
+        SensuMetrics().meldingTilRapidFeilet()
+        sikkerlogg.error("Sending til rapid feilet, exception: $e")
+        throw RapidsAndRiverException("Noe gikk feil ved publisering av melding")
+    }
+}

--- a/src/main/kotlin/no/nav/hjelpemidler/api/OrdrelinjeAPI.kt
+++ b/src/main/kotlin/no/nav/hjelpemidler/api/OrdrelinjeAPI.kt
@@ -130,7 +130,7 @@ private fun validerOrdrelinje(ordrelinje: OrdrelinjeOebs) {
     if (ordrelinje.hjelpemiddeltype != "Hjelpemiddel" &&
         ordrelinje.hjelpemiddeltype != "Individstyrt hjelpemiddel"
     ) {
-        logg.info("Mottok melding fra oebs med hjelpemiddeltype ${ordrelinje.hjelpemiddeltype}.")
+        logg.info("Mottok melding fra oebs med irrelevant hjelpemiddeltype ${ordrelinje.hjelpemiddeltype}. Avbryter prosessering")
         SensuMetrics().irrelevantHjelpemiddeltype()
         throw RuntimeException("Ugyldig ordrelinje")
     } else {

--- a/src/main/kotlin/no/nav/hjelpemidler/api/RapidsAndRiverException.kt
+++ b/src/main/kotlin/no/nav/hjelpemidler/api/RapidsAndRiverException.kt
@@ -1,0 +1,3 @@
+package no.nav.hjelpemidler.api
+
+class RapidsAndRiverException(message: String) : Exception(message)

--- a/src/main/kotlin/no/nav/hjelpemidler/metrics/SensuMetrics.kt
+++ b/src/main/kotlin/no/nav/hjelpemidler/metrics/SensuMetrics.kt
@@ -66,7 +66,7 @@ class SensuMetrics {
     }
 
     fun manglendeFeltForVedtakHOTSAK() {
-        registerPoint(OEBS_MELDING_MANGLENDE_FELT_INFOTRYGD, mapOf("counter" to 1L), emptyMap())
+        registerPoint(OEBS_MELDING_MANGLENDE_FELT_HOTSAK, mapOf("counter" to 1L), emptyMap())
     }
 
     private fun registerPoint(measurement: String, fields: Map<String, Any>, tags: Map<String, String>) {

--- a/src/main/kotlin/no/nav/hjelpemidler/metrics/SensuMetrics.kt
+++ b/src/main/kotlin/no/nav/hjelpemidler/metrics/SensuMetrics.kt
@@ -62,7 +62,11 @@ class SensuMetrics {
     }
 
     fun manglendeFeltForVedtakInfotrygd() {
-        registerPoint(OEBS_MELDING_MANGLENDE_FELT, mapOf("counter" to 1L), emptyMap())
+        registerPoint(OEBS_MELDING_MANGLENDE_FELT_INFOTRYGD, mapOf("counter" to 1L), emptyMap())
+    }
+
+    fun manglendeFeltForVedtakHOTSAK() {
+        registerPoint(OEBS_MELDING_MANGLENDE_FELT_INFOTRYGD, mapOf("counter" to 1L), emptyMap())
     }
 
     private fun registerPoint(measurement: String, fields: Map<String, Any>, tags: Map<String, String>) {
@@ -126,7 +130,8 @@ class SensuMetrics {
         const val OEBS_MELDING_SF_TYPE_ULIK_VEDTAK_INFOTRYGD = "$SOKNADER.oebs.sfTypeUlikVedtakInfotrygd"
         const val OEBS_MELDING_RETT_HJELPEMIDDELTYPE = "$SOKNADER.oebs.rettHjelpemiddeltype"
         const val OEBS_MELDING_IRRELEVANT_HJELPEMIDDELTYPE = "$SOKNADER.oebs.irrelevantHjelpemiddeltype"
-        const val OEBS_MELDING_MANGLENDE_FELT = "$SOKNADER.oebs.manglendeFeltForVedtakInfotrygd"
+        const val OEBS_MELDING_MANGLENDE_FELT_INFOTRYGD = "$SOKNADER.oebs.manglendeFeltForVedtakInfotrygd"
+        const val OEBS_MELDING_MANGLENDE_FELT_HOTSAK = "$SOKNADER.oebs.manglendeFeltForVedtakHotsak"
 
         // For å unngå problem med at to eventar blir logga på samme millisekund til InfluxDb, legg vi til ein aukande
         // counter som "fakar" auka oppløysing i nanosekund. Det blir lagt til eit tal modulo 1000000 for at det skal

--- a/src/main/kotlin/no/nav/hjelpemidler/model/HotsakOrdrelinje.kt
+++ b/src/main/kotlin/no/nav/hjelpemidler/model/HotsakOrdrelinje.kt
@@ -1,0 +1,36 @@
+package no.nav.hjelpemidler.model
+
+import com.fasterxml.jackson.annotation.JsonFormat
+import java.time.LocalDate
+
+data class HotsakOrdrelinje(
+    val mottakendeSystem: String,
+    val oebsId: Int,
+    val serviceforespørsel: Int,
+    val serviceforespørselstatus: String,
+    val serviceforespørseltype: String,
+    val søknadstype: String,
+
+    // N.B.: Viss dato er "" i meldinga blir den til null under deserialisering og forblir null under serialisering (utgåande JSON)
+    @JsonFormat(shape = JsonFormat.Shape.STRING)
+    val vedtaksdato: LocalDate?,
+
+    val søknad: String,
+    val resultat: String,
+    val saksnummer: String,
+    val ordrenr: Int,
+    val ordrelinje: Int,
+    val delordrelinje: Int,
+    val artikkelbeskrivelse: String,
+    val produktgruppe: String,
+    val produktgruppeNr: String,
+    val artikkelnr: String,
+    val hjelpemiddeltype: String,
+    val antall: Double,
+    val enhet: String,
+    val fnrBruker: String,
+    val egenAnsatt: String,
+
+    @JsonFormat(shape = JsonFormat.Shape.STRING)
+    val sistOppdatert: LocalDate
+): Ordrelinje

--- a/src/main/kotlin/no/nav/hjelpemidler/model/InfotrygdOrdrelinje.kt
+++ b/src/main/kotlin/no/nav/hjelpemidler/model/InfotrygdOrdrelinje.kt
@@ -1,0 +1,36 @@
+package no.nav.hjelpemidler.model
+
+import com.fasterxml.jackson.annotation.JsonFormat
+import java.time.LocalDate
+
+data class InfotrygdOrdrelinje(
+    val mottakendeSystem: String,
+    val oebsId: Int,
+    val serviceforespørsel: Int,
+    val serviceforespørselstatus: String,
+    val serviceforespørseltype: String,
+    val søknadstype: String,
+
+    // N.B.: Viss dato er "" i meldinga blir den til null under deserialisering og forblir null under serialisering (utgåande JSON)
+    @JsonFormat(shape = JsonFormat.Shape.STRING)
+    val vedtaksdato: LocalDate?,
+
+    val søknad: String,
+    val resultat: String,
+    val saksblokkOgSaksnr: String,
+    val ordrenr: Int,
+    val ordrelinje: Int,
+    val delordrelinje: Int,
+    val artikkelbeskrivelse: String,
+    val produktgruppe: String,
+    val produktgruppeNr: String,
+    val artikkelnr: String,
+    val hjelpemiddeltype: String,
+    val antall: Double,
+    val enhet: String,
+    val fnrBruker: String,
+    val egenAnsatt: String,
+
+    @JsonFormat(shape = JsonFormat.Shape.STRING)
+    val sistOppdatert: LocalDate
+) : Ordrelinje

--- a/src/main/kotlin/no/nav/hjelpemidler/model/Message.kt
+++ b/src/main/kotlin/no/nav/hjelpemidler/model/Message.kt
@@ -1,0 +1,16 @@
+package no.nav.hjelpemidler.model
+
+import com.fasterxml.jackson.annotation.JsonFormat
+import java.time.LocalDateTime
+import java.util.UUID
+
+data class Message(
+    val eventId: UUID,
+    val eventName: String,
+    @JsonFormat(shape = JsonFormat.Shape.STRING)
+    val opprettet: LocalDateTime,
+    val fnrBruker: String,
+    val data: Ordrelinje,
+)
+
+

--- a/src/main/kotlin/no/nav/hjelpemidler/model/Ordrelinje.kt
+++ b/src/main/kotlin/no/nav/hjelpemidler/model/Ordrelinje.kt
@@ -1,36 +1,3 @@
 package no.nav.hjelpemidler.model
 
-import com.fasterxml.jackson.annotation.JsonFormat
-import java.time.LocalDate
-
-data class Ordrelinje(
-    val mottakendeSystem: String,
-    val oebsId: Int,
-    val serviceforespørsel: Int,
-    val serviceforespørselstatus: String,
-    val serviceforespørseltype: String,
-    val søknadstype: String,
-
-    // N.B.: Viss dato er "" i meldinga blir den til null under deserialisering og forblir null under serialisering (utgåande JSON)
-    @JsonFormat(shape = JsonFormat.Shape.STRING)
-    val vedtaksdato: LocalDate?,
-
-    val søknad: String,
-    val resultat: String,
-    val saksblokkOgSaksnr: String,
-    val ordrenr: Int,
-    val ordrelinje: Int,
-    val delordrelinje: Int,
-    val artikkelbeskrivelse: String,
-    val produktgruppe: String,
-    val produktgruppeNr: String,
-    val artikkelnr: String,
-    val hjelpemiddeltype: String,
-    val antall: Double,
-    val enhet: String,
-    val fnrBruker: String,
-    val egenAnsatt: String,
-
-    @JsonFormat(shape = JsonFormat.Shape.STRING)
-    val sistOppdatert: LocalDate
-)
+interface Ordrelinje

--- a/src/main/kotlin/no/nav/hjelpemidler/model/OrdrelinjeOebs.kt
+++ b/src/main/kotlin/no/nav/hjelpemidler/model/OrdrelinjeOebs.kt
@@ -5,6 +5,9 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import com.fasterxml.jackson.annotation.JsonProperty
 import java.time.LocalDate
 
+const val HOTSAK = "HOTSAK"
+const val INFOTRYGD = "INFOTRYGD"
+
 @JsonIgnoreProperties(ignoreUnknown = true)
 data class OrdrelinjeOebs(
     @JsonProperty("System")
@@ -32,6 +35,12 @@ data class OrdrelinjeOebs(
 
     @JsonProperty("IncidentSoknad")
     val søknad: String,
+
+    @JsonProperty("ReferanseNummer")
+    val hotSakSaksnummer: String?,
+
+    @JsonProperty("Kilde")
+    val kilde: String?,
 
     @JsonProperty("IncidentResultat")
     val resultat: String,
@@ -83,8 +92,39 @@ data class OrdrelinjeOebs(
     val sistOppdatert: LocalDate
 )
 
-fun OrdrelinjeOebs.toOrdrelinje(): Ordrelinje {
-    return Ordrelinje(
+fun OrdrelinjeOebs.erOpprettetFraHOTSAK() = kilde != null && kilde == HOTSAK
+
+fun OrdrelinjeOebs.toHotsakOrdrelinje(): HotsakOrdrelinje {
+    return HotsakOrdrelinje(
+        mottakendeSystem = this.mottakendeSystem,
+        oebsId= this.oebsId,
+        serviceforespørsel = this.serviceforespørsel,
+        serviceforespørselstatus = this.serviceforespørselstatus,
+        serviceforespørseltype = this.serviceforespørseltype,
+        søknadstype = this.søknadstype,
+        vedtaksdato = this.vedtaksdato,
+        søknad = this.søknad,
+        resultat = this.resultat,
+        saksnummer = this.hotSakSaksnummer ?: "",
+        ordrenr = this.ordrenr,
+        ordrelinje = this.ordrelinje,
+        delordrelinje = this.delordrelinje,
+        artikkelbeskrivelse = this.artikkelbeskrivelse,
+        produktgruppe = this.produktgruppe,
+        produktgruppeNr = this.produktgruppeNr,
+        artikkelnr = this.artikkelnr,
+        hjelpemiddeltype = this.hjelpemiddeltype,
+        antall = this.antall,
+        enhet = this.enhet,
+        fnrBruker = this.fnrBruker,
+        egenAnsatt = this.egenAnsatt,
+        sistOppdatert = this.sistOppdatert
+    )
+
+}
+
+fun OrdrelinjeOebs.toOrdrelinje(): InfotrygdOrdrelinje {
+    return InfotrygdOrdrelinje(
         this.mottakendeSystem,
         this.oebsId,
         this.serviceforespørsel,

--- a/src/main/kotlin/no/nav/hjelpemidler/model/OrdrelinjeOebs.kt
+++ b/src/main/kotlin/no/nav/hjelpemidler/model/OrdrelinjeOebs.kt
@@ -46,7 +46,7 @@ data class OrdrelinjeOebs(
     val resultat: String,
 
     @JsonProperty("IncidentRef")
-    val saksblokkOgSaksnr: String,
+    val saksblokkOgSaksnr: String?,
 
     @JsonProperty("OrdreNumber")
     val ordrenr: Int,
@@ -134,7 +134,7 @@ fun OrdrelinjeOebs.toOrdrelinje(): InfotrygdOrdrelinje {
         this.vedtaksdato,
         this.søknad,
         this.resultat,
-        this.saksblokkOgSaksnr,
+        this.saksblokkOgSaksnr ?: "",
         this.ordrenr,
         this.ordrelinje,
         this.delordrelinje,


### PR DESCRIPTION
Refaktorerer i håp om å forbedre lesbarheten. Det ble ganske komplekst å lese når alt lå i Application.kt og vi i tillegg innførte nye stier i koden for å skille på hotsak saker og infotrygd saker. 

Opprettet egen API klasse hvor håndtering POST kall til /push foregår 
Endret litt på flyt slik at det kastes Exceptions hvis valideringsstegene feiler som igjen sørger for at det returneres riktige respons koder.

Egne filer og funksjoner for håndtering av HotSak og Infotrygd 